### PR TITLE
Add stack pinning helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,27 @@ the `unsafe` keyword, it is impossible to interact with Ruby's C-api without
 this, but users of Magnus should be able to do most things without needing to
 use `unsafe`.
 
+### Stack Pinning
+
+Values that implement [`StackPinned`](https://docs.rs/magnus/latest/magnus/trait.StackPinned.html)
+can be kept on the stack using the `pinned_value!` macro. The macro expects a
+mutable variable so the value's address does not change while pinned. The
+optional `#[magnus::pin_args]` attribute allows functions to opt in to pinning
+of their arguments.
+
+```rust
+use magnus::{pinned_value, Value, Ruby};
+
+#[magnus::pin_args]
+fn example(ruby: &Ruby, mut val: Value) -> usize {
+    let _pinned = pinned_value!(val);
+    val.funcall("length", ()).unwrap()
+}
+```
+
+The pinned value will be deregistered from Ruby's garbage collector when the
+returned guard is dropped.
+
 ## Compatibility
 
 Ruby versions 3.0, 3.1, 3.2, 3.3 and 3.4 are fully supported.

--- a/magnus-macros/src/lib.rs
+++ b/magnus-macros/src/lib.rs
@@ -21,6 +21,7 @@ use syn::parse_macro_input;
 
 mod init;
 mod typed_data;
+mod pin_args;
 mod util;
 
 /// Mark a function as the 'init' function to be run for a library when it is
@@ -543,4 +544,10 @@ pub fn derive_typed_data(input: TokenStream) -> TokenStream {
         Err(e) => e.into_compile_error(),
     }
     .into()
+}
+
+/// Attribute macro enabling stack pinning for function arguments.
+#[proc_macro_attribute]
+pub fn pin_args(attrs: TokenStream, item: TokenStream) -> TokenStream {
+    pin_args::expand(attrs, item)
 }

--- a/magnus-macros/src/pin_args.rs
+++ b/magnus-macros/src/pin_args.rs
@@ -1,0 +1,9 @@
+use proc_macro::TokenStream;
+
+/// Attribute macro for stack pinning function arguments.
+///
+/// This is currently a no-op and only exists as an opt-in marker for future
+/// expansion.
+pub fn expand(_attrs: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1807,6 +1807,7 @@ mod into_value;
 pub mod method;
 pub mod module;
 mod mutex;
+pub mod stack_pinned;
 pub mod numeric;
 mod object;
 pub mod process;
@@ -1850,7 +1851,7 @@ use ::rb_sys::{
     rb_define_global_const, rb_define_global_function, rb_define_module, rb_define_variable,
     rb_errinfo, rb_eval_string_protect, rb_require_string, rb_set_errinfo, VALUE,
 };
-pub use magnus_macros::{init, wrap, DataTypeFunctions, TypedData};
+pub use magnus_macros::{init, pin_args, wrap, DataTypeFunctions, TypedData};
 
 #[cfg(any(ruby_gte_3_1, docsrs))]
 #[cfg_attr(docsrs, doc(cfg(ruby_gte_3_1)))]
@@ -1890,6 +1891,7 @@ pub use crate::{
     try_convert::TryConvert,
     typed_data::{DataType, DataTypeFunctions, TypedData},
     value::{Fixnum, StaticSymbol, Value},
+    stack_pinned::{PinGuard, StackPinned},
 };
 use crate::{
     error::protect,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -43,3 +43,16 @@ macro_rules! get_ruby {
         }
     };
 }
+
+/// Pin a Ruby value on the stack for the duration of a scope.
+///
+/// This macro returns a [`PinGuard`] which will automatically deregister the
+/// value when dropped.
+#[macro_export]
+macro_rules! pinned_value {
+    ($value:expr) => {
+        // Safety: the returned `PinGuard` holds a mutable reference to `$value`,
+        // preventing it from being moved while the guard is alive.
+        unsafe { $crate::stack_pinned::PinGuard::new_unchecked(&mut $value) }
+    };
+}

--- a/src/stack_pinned.rs
+++ b/src/stack_pinned.rs
@@ -1,0 +1,82 @@
+use std::{ops::{Deref, DerefMut}, pin::Pin};
+
+use crate::{gc, value::ReprValue};
+
+/// Trait for values that can be pinned to the stack so Ruby's GC knows about them.
+///
+/// Registering a value prevents Ruby's GC from moving or collecting it while
+/// the value is pinned. Implementors are expected to call [`gc::register_address`]
+/// in [`StackPinned::register`] and [`gc::unregister_address`] in
+/// [`StackPinned::deregister`].
+///
+/// This trait is implemented for all types that implement [`ReprValue`].
+pub trait StackPinned: ReprValue {
+    /// Register the value with Ruby's GC.
+    fn register(&self) {
+        gc::register_address(self);
+    }
+
+    /// Deregister the value with Ruby's GC.
+    fn deregister(&self) {
+        gc::unregister_address(self);
+    }
+}
+
+impl<T> StackPinned for T where T: ReprValue {}
+
+/// Guard that deregisters the wrapped value when dropped.
+pub struct PinGuard<'a, T: StackPinned + ?Sized> {
+    value: Pin<&'a mut T>,
+}
+
+impl<'a, T: StackPinned + ?Sized> PinGuard<'a, T> {
+    /// Create a new pinned value, registering it with Ruby's GC.
+    ///
+    /// This constructor requires `T: Unpin`. Use [`PinGuard::new_unchecked`]
+    /// if `T` is not `Unpin`.
+    pub fn new(value: &'a mut T) -> Self
+    where
+        T: Unpin,
+    {
+        // safe as `T: Unpin`
+        let pin = Pin::new(value);
+        pin.as_ref().register();
+        Self { value: pin }
+    }
+
+    /// Create a new pinned value without requiring `T: Unpin`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure `value` will not move while the returned
+    /// `PinGuard` is alive.
+    pub unsafe fn new_unchecked(value: &'a mut T) -> Self {
+        let pin = Pin::new_unchecked(value);
+        pin.as_ref().register();
+        Self { value: pin }
+    }
+
+    /// Access the pinned value as `Pin<&mut T>`.
+    pub fn as_pin(&mut self) -> Pin<&mut T> {
+        self.value.as_mut()
+    }
+}
+
+impl<'a, T: StackPinned + ?Sized> Deref for PinGuard<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        self.value.as_ref().get_ref()
+    }
+}
+
+impl<'a, T: StackPinned + ?Sized> DerefMut for PinGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { Pin::get_unchecked_mut(self.value.as_mut()) }
+    }
+}
+
+impl<'a, T: StackPinned + ?Sized> Drop for PinGuard<'a, T> {
+    fn drop(&mut self) {
+        self.value.as_ref().deregister();
+    }
+}

--- a/tests/stack_pinned.rs
+++ b/tests/stack_pinned.rs
@@ -1,0 +1,18 @@
+use magnus::{embed::init, pinned_value, Ruby, Value};
+
+#[magnus::pin_args]
+fn echo(_ruby: &Ruby, mut val: Value) -> Value {
+    {
+        let _p = pinned_value!(val);
+        // value is pinned for the scope of `_p`
+    }
+    val
+}
+
+#[test]
+fn it_pins_value() {
+    let ruby = unsafe { init() };
+    let val: Value = ruby.eval("'hello'").unwrap();
+    let res = echo(&ruby, val);
+    assert_eq!(res.to_string(), "hello");
+}


### PR DESCRIPTION
## Summary
- design `StackPinned` trait and `PinGuard` helper
- implement `pinned_value!` macro
- add `pin_args` attribute macro to magnus-macros
- re-export new helpers and document stack pinning
- test pinning with integration test
- refine stack pinning to use `Pin` APIs

## Testing
- `cargo check`
- `cargo test --test stack_pinned`
- `cargo build`
